### PR TITLE
fix: use job-level env for secrets check in EAS Update workflow

### DIFF
--- a/.github/workflows/eas-update-preview.yml
+++ b/.github/workflows/eas-update-preview.yml
@@ -10,6 +10,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      HAS_EXPO_TOKEN: ${{ secrets.EXPO_TOKEN != '' }}
 
     steps:
       - name: Checkout repository
@@ -25,14 +27,14 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Setup EAS CLI
-        if: ${{ secrets.EXPO_TOKEN != '' }}
+        if: env.HAS_EXPO_TOKEN == 'true'
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Publish EAS update for PR
-        if: ${{ secrets.EXPO_TOKEN != '' }}
+        if: env.HAS_EXPO_TOKEN == 'true'
         id: publish
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -56,7 +58,7 @@ jobs:
       - name: Comment PR with preview details
         uses: actions/github-script@v7
         env:
-          HAS_TOKEN: ${{ secrets.EXPO_TOKEN != '' }}
+          HAS_TOKEN: ${{ env.HAS_EXPO_TOKEN }}
           BRANCH_NAME: ${{ steps.publish.outputs.branch }}
           EAS_OUTPUT: ${{ steps.publish.outputs.output }}
           PROJECT_ID: 4b307517-1d0f-4664-b174-636b2382ae68


### PR DESCRIPTION
## Summary
- GitHub Actions doesn't allow `secrets` context in step-level `if` expressions, causing "Unrecognized named-value: 'secrets'" validation errors
- Moved the `secrets.EXPO_TOKEN != ''` check to a job-level `env` variable (`HAS_EXPO_TOKEN`) and reference it in step `if` conditions instead

## Test plan
- [ ] This PR itself should trigger the EAS Update Preview workflow without validation errors
- [ ] Verify the PR comment appears (either with preview link or "skipped" message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)